### PR TITLE
Update to wgpu 0.19, cross-platform

### DIFF
--- a/na-winit-wgpu/Cargo.lock
+++ b/na-winit-wgpu/Cargo.lock
@@ -19,21 +19,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
 
 [[package]]
-name = "addr2line"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,6 +27,19 @@ dependencies = [
  "getrandom",
  "once_cell",
  "version_check",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -55,13 +53,15 @@ dependencies = [
 
 [[package]]
 name = "android-activity"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c77a0045eda8b888c76ea473c2b0515ba6f471d318f8927c5c72240937035a6"
+checksum = "39b801912a977c3fd52d80511fe1c0c8480c6f957f21ae2ce1b92ffe970cf4b9"
 dependencies = [
  "android-properties",
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "cc",
+ "cesu8",
+ "jni",
  "jni-sys",
  "libc",
  "log",
@@ -69,6 +69,7 @@ dependencies = [
  "ndk-context",
  "ndk-sys",
  "num_enum",
+ "thiserror",
 ]
 
 [[package]]
@@ -79,15 +80,15 @@ checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
 name = "android_log-sys"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85965b6739a430150bdd138e2374a98af0c3ee0d030b3bb7fc3bddff58d0102e"
+checksum = "5ecc8056bf6ab9892dcd53216c83d1597487d7dacac16c8df6b877d127df9937"
 
 [[package]]
 name = "android_logger"
-version = "0.11.3"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8619b80c242aa7bd638b5c7ddd952addeecb71f69c75e33f1d47b2804f8f883a"
+checksum = "c494134f746c14dc653a35a4ea5aca24ac368529da5370ecf41fe0341c35772f"
 dependencies = [
  "android_log-sys",
  "env_logger",
@@ -117,34 +118,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
-name = "ash"
-version = "0.37.2+1.3.238"
+name = "as-raw-xcb-connection"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28bf19c1f0a470be5fbf7522a308a05df06610252c5bcf5143e1b23f629a9a03"
+checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
+
+[[package]]
+name = "ash"
+version = "0.37.3+1.3.251"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e9c3835d686b0a6084ab4234fcd1b07dbf6e4767dce60874b12356a25ecd4a"
 dependencies = [
  "libloading 0.7.4",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "backtrace"
-version = "0.3.67"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide 0.6.2",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "bit-set"
@@ -169,9 +167,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6776fc96284a0bb647b615056fc496d1fe1644a7ab01829818a6d91cae888b84"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "block"
@@ -181,21 +179,21 @@ checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-sys"
-version = "0.1.0-beta.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa55741ee90902547802152aaf3f8e5248aab7e21468089560d4c8840561146"
+checksum = "ae85a0696e7ea3b835a453750bf002770776609115e6d25c6d2ff28a8200f7e7"
 dependencies = [
  "objc-sys",
 ]
 
 [[package]]
 name = "block2"
-version = "0.2.0-alpha.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd9e63c1744f755c2f60332b88de39d341e5e86239014ad839bd71c106dec42"
+checksum = "15b55663a85f33501257357e6421bb33e769d5c9ffb5ba0921c975a123e35e68"
 dependencies = [
  "block-sys",
- "objc2-encode",
+ "objc2",
 ]
 
 [[package]]
@@ -211,16 +209,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
 
 [[package]]
-name = "calloop"
-version = "0.10.5"
+name = "bytes"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a59225be45a478d772ce015d9743e49e92798ece9e34eda9a6aa2a6a7f40192"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+
+[[package]]
+name = "calloop"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298"
 dependencies = [
+ "bitflags 2.4.2",
  "log",
- "nix 0.25.1",
- "slotmap",
+ "polling",
+ "rustix 0.38.30",
+ "slab",
  "thiserror",
- "vec_map",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0ea9b9476c7fad82841a8dbb380e2eae480c21910feba80725b46931ed8f02"
+dependencies = [
+ "calloop",
+ "rustix 0.38.30",
+ "wayland-backend",
+ "wayland-client",
 ]
 
 [[package]]
@@ -231,6 +248,12 @@ checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 dependencies = [
  "jobserver",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -255,10 +278,74 @@ dependencies = [
 ]
 
 [[package]]
-name = "com-rs"
-version = "0.2.1"
+name = "com"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf43edc576402991846b093a7ca18a3477e0ef9c588cde84964b5d3e43016642"
+checksum = "7e17887fd17353b65b1b2ef1c526c83e26cd72e74f598a8dc1bee13a48f3d9f6"
+dependencies = [
+ "com_macros",
+]
+
+[[package]]
+name = "com_macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d375883580a668c7481ea6631fc1a8863e33cc335bf56bfad8d7e6d4b04b13a5"
+dependencies = [
+ "com_macros_support",
+ "proc-macro2",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "com_macros_support"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad899a1087a9296d5644792d7cb72b8e34c1bec8e7d4fbc002230169a6e8710c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "console_log"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8aed40e4edbf4d3b4431ab260b63fdc40f5780a4766824329ea0f1eefe3c0f"
+dependencies = [
+ "log",
+ "web-sys",
+]
 
 [[package]]
 name = "core-foundation"
@@ -278,14 +365,14 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "core-graphics"
-version = "0.22.3"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb"
+checksum = "970a29baf4110c26fedbc7f82107d42c23f7e88e404c4577ed73fe99ff85a212"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -297,27 +384,30 @@ checksum = "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.3.2"
+name = "crossbeam-utils"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
-dependencies = [
- "cfg-if",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "cursor-icon"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
 name = "d3d12"
-version = "0.6.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f0de2f5a8e7bd4a9eec0e3c781992a4ce1724f68aec7d7a3715344de8b39da"
+checksum = "3e3d747f100290a1ca24b752186f61f6637e1deffe3bf6320de6fcb29510a307"
 dependencies = [
- "bitflags 1.3.2",
- "libloading 0.7.4",
+ "bitflags 2.4.2",
+ "libloading 0.8.0",
  "winapi",
 ]
 
@@ -329,11 +419,11 @@ checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "dlib"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1b7517328c04c2aa68422fc60a41b92208182142ed04a25879c26c8f878794"
+checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.0",
 ]
 
 [[package]]
@@ -356,43 +446,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
- "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "fdeflate"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d329bdeac514ee06249dabc27877490f17f5d371ec693360768b838e19f3ae10"
-dependencies = [
- "simd-adler32",
-]
-
-[[package]]
-name = "flate2"
-version = "1.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
-dependencies = [
- "crc32fast",
- "miniz_oxide 0.7.1",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -401,7 +467,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -409,6 +496,22 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
+name = "gethostname"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
+dependencies = [
+ "libc",
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "getrandom"
@@ -422,16 +525,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.27.2"
+name = "gl_generator"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
 
 [[package]]
 name = "glow"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e007a07a24de5ecae94160f141029e9a347282cfe25d1d58d85d845cf3130f1"
+checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -440,32 +548,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "gpu-alloc"
-version = "0.5.4"
+name = "glutin_wgl_sys"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22beaafc29b38204457ea030f6fb7a84c9e4dd1b86e311ba0542533453d87f62"
+checksum = "6c8098adac955faa2d31079b65dc48841251f69efd3ac25477903fc424362ead"
 dependencies = [
- "bitflags 1.3.2",
+ "gl_generator",
+]
+
+[[package]]
+name = "gpu-alloc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
+dependencies = [
+ "bitflags 2.4.2",
  "gpu-alloc-types",
 ]
 
 [[package]]
 name = "gpu-alloc-types"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54804d0d6bc9d7f26db4eaec1ad10def69b599315f487d32c334a80d1efe67a5"
+checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
 ]
 
 [[package]]
 name = "gpu-allocator"
-version = "0.22.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce95f9e2e11c2c6fadfce42b5af60005db06576f231f5c92550fdded43c423e8"
+checksum = "6f56f6318968d03c18e1bcf4857ff88c61157e9da8e47c5f29055d60e1228884"
 dependencies = [
- "backtrace",
  "log",
+ "presser",
  "thiserror",
  "winapi",
  "windows",
@@ -479,7 +596,7 @@ checksum = "0b0c02e1ba0bdb14e965058ca34e09c020f8e507a760df1121728e0aef68d57a"
 dependencies = [
  "bitflags 1.3.2",
  "gpu-descriptor-types",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -497,19 +614,25 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
 ]
 
 [[package]]
-name = "hassle-rs"
-version = "0.10.0"
+name = "hashbrown"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1397650ee315e8891a0df210707f0fc61771b0cc518c3023896064c5407cb3b0"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "hassle-rs"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af2a7e73e1f34c48da31fb668a907f250794837e08faa144fd24f0b8b741e890"
 dependencies = [
- "bitflags 1.3.2",
- "com-rs",
+ "bitflags 2.4.2",
+ "com",
  "libc",
- "libloading 0.7.4",
+ "libloading 0.8.0",
  "thiserror",
  "widestring",
  "winapi",
@@ -534,25 +657,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "icrate"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d3aaff8a54577104bafdf686ff18565c3b6903ca5782a2026ef06e2c7aa319"
+dependencies = [
+ "block2",
+ "dispatch",
+ "objc2",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
+name = "indexmap"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
+ "equivalent",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -574,8 +706,24 @@ checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi",
  "io-lifetimes",
- "rustix",
+ "rustix 0.37.19",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -595,35 +743,35 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.63"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f37a4a5928311ac501dee68b3c7613a1037d0edb30c8e5427bd832d55d1b790"
+checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "khronos-egl"
-version = "4.1.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2352bd1d0bceb871cb9d40f24360c8133c11d7486b68b5381c1dd1a32015e3"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
 dependencies = [
  "libc",
- "libloading 0.7.4",
+ "libloading 0.8.0",
  "pkg-config",
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
+name = "khronos_api"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "libloading"
@@ -650,6 +798,12 @@ name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
@@ -684,34 +838,35 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.5.10"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+checksum = "45fd3a57831bf88bc63f8cebc0cf956116276e97fef3966103e96416209f7c92"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "metal"
-version = "0.24.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de11355d1f6781482d027a3b4d4de7825dcedb197bf573e0596d00008402d060"
+checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "block",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "log",
  "objc",
+ "paste",
 ]
 
 [[package]]
@@ -721,59 +876,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
-dependencies = [
- "adler",
- "simd-adler32",
-]
-
-[[package]]
-name = "mio"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebffdb73fe72e917997fad08bdbf31ac50b0fa91cec93e69a0662e4264d454c"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "na-winit-wgpu"
 version = "0.1.0"
 dependencies = [
  "android_logger",
+ "cfg-if",
+ "console_error_panic_hook",
+ "console_log",
  "env_logger",
  "log",
  "pollster",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
  "wgpu",
  "winit",
 ]
 
 [[package]]
 name = "naga"
-version = "0.12.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d3edd593521f4a1dfd9b25193ed0224764572905f013d30ca5fbb85e010876"
+checksum = "8878eb410fc90853da3908aebfe61d73d26d4437ef850b70050461f939509899"
 dependencies = [
  "bit-set",
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "codespan-reporting",
  "hexf-parse",
- "indexmap",
+ "indexmap 2.1.0",
  "log",
  "num-traits",
  "rustc-hash",
@@ -785,12 +915,13 @@ dependencies = [
 
 [[package]]
 name = "ndk"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451422b7e4718271c8b5b3aadf5adedba43dc76312454b387e98fae0fc951aa0"
+checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "jni-sys",
+ "log",
  "ndk-sys",
  "num_enum",
  "raw-window-handle",
@@ -805,32 +936,19 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
-version = "0.4.1+23.1.7779620"
+version = "0.5.0+25.2.9519653"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf2aae958bd232cac5069850591667ad422d263686d75b52a065f9badeee5a3"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
 dependencies = [
  "jni-sys",
 ]
 
 [[package]]
 name = "nix"
-version = "0.24.3"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset",
-]
-
-[[package]]
-name = "nix"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
-dependencies = [
- "autocfg",
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
@@ -858,23 +976,23 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.11"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -889,29 +1007,25 @@ dependencies = [
 
 [[package]]
 name = "objc-sys"
-version = "0.2.0-beta.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b9834c1e95694a05a828b59f55fa2afec6288359cda67146126b3f90a55d7"
+checksum = "c7c71324e4180d0899963fc83d9d241ac39e699609fc1025a850aadac8257459"
 
 [[package]]
 name = "objc2"
-version = "0.3.0-beta.3.patch-leaks.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e01640f9f2cb1220bbe80325e179e532cb3379ebcd1bf2279d703c19fe3a468"
+checksum = "559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d"
 dependencies = [
- "block2",
  "objc-sys",
  "objc2-encode",
 ]
 
 [[package]]
 name = "objc2-encode"
-version = "2.0.0-pre.2"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abfcac41015b00a120608fdaa6938c44cb983fee294351cc4bac7638b4e50512"
-dependencies = [
- "objc-sys",
-]
+checksum = "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666"
 
 [[package]]
 name = "objc_exception"
@@ -923,19 +1037,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.30.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "orbclient"
@@ -979,10 +1084,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pkg-config"
@@ -991,23 +1108,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
-name = "png"
-version = "0.17.8"
+name = "polling"
+version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaeebc51f9e7d2c150d3f3bfeb667f2aa985db5ef1e3d212847bdedb488beeaa"
+checksum = "545c980a3880efd47b2e262f6a4bb6daad6555cf3367aa9c4e52895f69537a41"
 dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide 0.7.1",
+ "cfg-if",
+ "concurrent-queue",
+ "pin-project-lite",
+ "rustix 0.38.30",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "pollster"
-version = "0.2.5"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da3b0203fd7ee5720aa0b5e790b591aa5d3f41c3ed2c34a3a393382198af2f7"
+checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
+
+[[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "proc-macro-crate"
@@ -1021,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
@@ -1035,10 +1159,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "332cd62e95873ea4f41f3dfd6bbbfc5b52aec892d7e8d534197c4720a0bbbab2"
 
 [[package]]
-name = "quote"
-version = "1.0.28"
+name = "quick-xml"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -1051,9 +1184,9 @@ checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
 
 [[package]]
 name = "raw-window-handle"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
+checksum = "42a9830a0e1b9fb145ebb365b8bc4ccd75f290f98c0247deafbbe2c75cefb544"
 
 [[package]]
 name = "redox_syscall"
@@ -1097,12 +1230,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216080ab382b992234dda86873c18d4c48358f5cfcb70fd693d7f6f2131b628b"
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,8 +1245,30 @@ dependencies = [
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.8",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
+dependencies = [
+ "bitflags 2.4.2",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.13",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1136,9 +1285,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sctk-adwaita"
-version = "0.5.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda4e97be1fd174ccc2aae81c8b694e803fa99b34e8fd0f057a9d70698e3ed09"
+checksum = "82b2eaf3a5b264a521b988b2e73042e742df700c4f962cde845d1541adb46550"
 dependencies = [
  "ab_glyph",
  "log",
@@ -1148,10 +1297,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.5"
+name = "serde"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238abfbb77c1915110ad968465608b68e869e0772622c9656714e73e5a1a522f"
+checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.195"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "slotmap"
@@ -1170,31 +1342,45 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.16.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f307c47d32d2715eb2e0ece5589057820e0e5e70d07c247d1063e844e107f454"
+checksum = "60e3d9941fa3bacf7c2bf4b065304faa14164151254cd16ce1b1bc8fc381600f"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "calloop",
- "dlib",
- "lazy_static",
+ "calloop-wayland-source",
+ "cursor-icon",
+ "libc",
  "log",
  "memmap2",
- "nix 0.24.3",
- "pkg-config",
+ "rustix 0.38.30",
+ "thiserror",
+ "wayland-backend",
  "wayland-client",
+ "wayland-csd-frame",
  "wayland-cursor",
  "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6845563ada680337a52d43bb0b29f396f2d911616f6573012645b9e3d048a49"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
 name = "spirv"
-version = "0.2.0+1.5.4"
+version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246bfa38fe3db3f1dfc8ca5a2cdeb7348c78be2112740cc0ec8ef18b6d94f830"
+checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "bitflags 1.3.2",
- "num-traits",
+ "bitflags 2.4.2",
 ]
 
 [[package]]
@@ -1222,9 +1408,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1233,52 +1419,52 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.2.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "tiny-skia"
-version = "0.8.4"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8493a203431061e901613751931f047d1971337153f96d0e5e363d6dbf6a67"
+checksum = "b6a067b809476893fce6a254cf285850ff69c847e6cfbade6a20b655b6c7e80d"
 dependencies = [
  "arrayref",
  "arrayvec",
  "bytemuck",
  "cfg-if",
- "png",
+ "log",
  "tiny-skia-path",
 ]
 
 [[package]]
 name = "tiny-skia-path"
-version = "0.8.4"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbfb5d3f3dd57a0e11d12f4f13d4ebbbc1b5c15b7ab0a156d030b21da5f677c"
+checksum = "5de35e8a90052baaaf61f171680ac2f8e925a1e43ea9d2e3a00514772250e541"
 dependencies = [
  "arrayref",
  "bytemuck",
@@ -1297,10 +1483,26 @@ version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 
 [[package]]
 name = "ttf-parser"
@@ -1315,6 +1517,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,16 +1535,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -1346,9 +1558,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.86"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bba0e8cb82ba49ff4e229459ff22a191bbe9a1cb3a341610c9c33efc27ddf73"
+checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1356,24 +1568,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.86"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b04bc93f9d6bdee709f6bd2118f57dd6679cf1176a1af464fca3ab0d66d8fb"
+checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.36"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1985d03709c53167ce907ff394f5316aa22cb4e12761295c5dc57dacb6297e"
+checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1383,9 +1595,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.86"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d6b024f1a526bb0234f52840389927257beb670610081360e5a03c5df9c258"
+checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1393,101 +1605,147 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.86"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
+checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.86"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
+checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
-name = "wayland-client"
-version = "0.29.5"
+name = "wayland-backend"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3b068c05a039c9f755f881dc50f01732214f5685e379829759088967c46715"
+checksum = "19152ddd73f45f024ed4534d9ca2594e0ef252c1847695255dae47f34df9fbe4"
 dependencies = [
- "bitflags 1.3.2",
+ "cc",
  "downcast-rs",
- "libc",
- "nix 0.24.3",
+ "nix",
  "scoped-tls",
- "wayland-commons",
- "wayland-scanner",
- "wayland-sys",
-]
-
-[[package]]
-name = "wayland-commons"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8691f134d584a33a6606d9d717b95c4fa20065605f798a3f350d78dced02a902"
-dependencies = [
- "nix 0.24.3",
- "once_cell",
  "smallvec",
  "wayland-sys",
 ]
 
 [[package]]
-name = "wayland-cursor"
-version = "0.29.5"
+name = "wayland-client"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6865c6b66f13d6257bef1cd40cbfe8ef2f150fb8ebbdb1e8e873455931377661"
+checksum = "1ca7d52347346f5473bf2f56705f360e8440873052e575e55890c4fa57843ed3"
 dependencies = [
- "nix 0.24.3",
+ "bitflags 2.4.2",
+ "nix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-csd-frame"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
+dependencies = [
+ "bitflags 2.4.2",
+ "cursor-icon",
+ "wayland-backend",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44aa20ae986659d6c77d64d808a046996a932aa763913864dc40c359ef7ad5b"
+dependencies = [
+ "nix",
  "wayland-client",
  "xcursor",
 ]
 
 [[package]]
 name = "wayland-protocols"
-version = "0.29.5"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b950621f9354b322ee817a23474e479b34be96c2e909c14f7bc0100e9a970bc6"
+checksum = "e253d7107ba913923dc253967f35e8561a3c65f914543e46843c88ddd729e21c"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
+ "wayland-backend",
  "wayland-client",
- "wayland-commons",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-plasma"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23803551115ff9ea9bce586860c5c5a971e360825a0309264102a9495a5ff479"
+dependencies = [
+ "bitflags 2.4.2",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
+dependencies = [
+ "bitflags 2.4.2",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 
 [[package]]
 name = "wayland-scanner"
-version = "0.29.5"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4303d8fa22ab852f789e75a967f0a2cdc430a607751c0499bada3e451cbd53"
+checksum = "fb8e28403665c9f9513202b7e1ed71ec56fde5c107816843fb14057910b2c09c"
 dependencies = [
  "proc-macro2",
+ "quick-xml",
  "quote",
- "xml-rs",
 ]
 
 [[package]]
 name = "wayland-sys"
-version = "0.29.5"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be12ce1a3c39ec7dba25594b97b42cb3195d54953ddb9d3d95a7c3902bc6e9d4"
+checksum = "15a0c8eaff5216d07f226cb7a549159267f3467b289d9a2e52fd3ef5aae2b7af"
 dependencies = [
  "dlib",
- "lazy_static",
+ "log",
+ "once_cell",
  "pkg-config",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.63"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bdd9ef4e984da1187bf8110c5cf5b845fbc87a23602cdf912386a76fcd3a7c2"
+checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1495,12 +1753,13 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "0.16.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3059ea4ddec41ca14f356833e2af65e7e38c0a8f91273867ed526fb9bafcca95"
+checksum = "d0b71d2ded29e2161db50ab731d6cb42c037bd7ab94864a98fa66ff36b4721a8"
 dependencies = [
  "arrayvec",
  "cfg-if",
+ "cfg_aliases",
  "js-sys",
  "log",
  "naga",
@@ -1519,16 +1778,19 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.16.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f478237b4bf0d5b70a39898a66fa67ca3a007d79f2520485b8b0c3dfc46f8c2"
+checksum = "6b15e451d4060ada0d99a64df44e4d590213496da7c4f245572d51071e8e30ed"
 dependencies = [
  "arrayvec",
  "bit-vec",
- "bitflags 2.3.1",
+ "bitflags 2.4.2",
+ "cfg_aliases",
  "codespan-reporting",
+ "indexmap 2.1.0",
  "log",
  "naga",
+ "once_cell",
  "parking_lot",
  "profiling",
  "raw-window-handle",
@@ -1542,20 +1804,21 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.16.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41af2ea7d87bd41ad0a37146252d5f7c26490209f47f544b2ee3b3ff34c7732e"
+checksum = "11f259ceb56727fb097da108d92f8a5cbdb5b74a77f9e396bd43626f67299d61"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags 2.3.1",
+ "bitflags 2.4.2",
  "block",
+ "cfg_aliases",
  "core-graphics-types",
  "d3d12",
- "foreign-types",
  "glow",
+ "glutin_wgl_sys",
  "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
@@ -1568,6 +1831,7 @@ dependencies = [
  "metal",
  "naga",
  "objc",
+ "once_cell",
  "parking_lot",
  "profiling",
  "range-alloc",
@@ -1584,11 +1848,11 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.16.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd33a976130f03dcdcd39b3810c0c3fc05daf86f0aaf867db14bfb7c4a9a32b"
+checksum = "895fcbeb772bfb049eb80b2d6e47f6c9af235284e9703c96fc0218a42ffd5af2"
 dependencies = [
- "bitflags 2.3.1",
+ "bitflags 2.4.2",
  "js-sys",
  "web-sys",
 ]
@@ -1632,11 +1896,21 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.44.0"
+version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
+checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
 dependencies = [
- "windows-targets 0.42.2",
+ "windows-core",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1654,7 +1928,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -1674,17 +1957,32 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -1695,9 +1993,15 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1707,9 +2011,15 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1719,9 +2029,15 @@ checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1731,9 +2047,15 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1743,9 +2065,15 @@ checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1755,9 +2083,15 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1767,43 +2101,62 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winit"
-version = "0.28.6"
+version = "0.29.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "866db3f712fffba75d31bf0cdecf357c8aeafd158c5b7ab51dba2a2b2d47f196"
+checksum = "4c824f11941eeae66ec71111cc2674373c772f482b58939bb4066b642aa2ffcf"
 dependencies = [
+ "ahash 0.8.7",
  "android-activity",
- "bitflags 1.3.2",
+ "atomic-waker",
+ "bitflags 2.4.2",
+ "bytemuck",
+ "calloop",
  "cfg_aliases",
  "core-foundation",
  "core-graphics",
- "dispatch",
- "instant",
+ "cursor-icon",
+ "icrate",
+ "js-sys",
  "libc",
  "log",
- "mio",
+ "memmap2",
  "ndk",
+ "ndk-sys",
  "objc2",
  "once_cell",
  "orbclient",
  "percent-encoding",
  "raw-window-handle",
  "redox_syscall 0.3.5",
+ "rustix 0.38.30",
  "sctk-adwaita",
  "smithay-client-toolkit",
+ "smol_str",
+ "unicode-segmentation",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wayland-backend",
  "wayland-client",
- "wayland-commons",
  "wayland-protocols",
- "wayland-scanner",
+ "wayland-protocols-plasma",
  "web-sys",
- "windows-sys 0.45.0",
+ "web-time",
+ "windows-sys 0.48.0",
  "x11-dl",
+ "x11rb",
+ "xkbcommon-dl",
 ]
 
 [[package]]
@@ -1827,6 +2180,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "x11rb"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8f25ead8c7e4cba123243a6367da5d3990e0d3affa708ea19dce96356bd9f1a"
+dependencies = [
+ "as-raw-xcb-connection",
+ "gethostname",
+ "libc",
+ "libloading 0.8.0",
+ "once_cell",
+ "rustix 0.38.30",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34"
+
+[[package]]
 name = "xcursor"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,7 +2210,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "xkbcommon-dl"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6924668544c48c0133152e7eec86d644a056ca3d09275eb8d5cdb9855f9d8699"
+dependencies = [
+ "bitflags 2.4.2",
+ "dlib",
+ "log",
+ "once_cell",
+ "xkeysym",
+]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054a8e68b76250b253f671d1268cb7f1ae089ec35e195b2efb2a4e9a836d0621"
+
+[[package]]
 name = "xml-rs"
 version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d8f380ae16a37b30e6a2cf67040608071384b1450c189e61bea3ff57cde922d"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]

--- a/na-winit-wgpu/Cargo.toml
+++ b/na-winit-wgpu/Cargo.toml
@@ -7,15 +7,36 @@ edition = "2021"
 
 [dependencies]
 log = "0.4"
-winit = { version = "0.28", features = ["android-native-activity"] }
-wgpu = "0.16"
-pollster = "0.2"
+winit = { version = "0.29", features = ["android-native-activity"] }
+wgpu = "0.19"
+pollster = "0.3"
+cfg-if = "1.0"
+
+#[target.'cfg(target_arch = "wasm32")'.dependencies]
+console_error_panic_hook = "0.1"
+console_log = "1.0"
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+web-sys = { version = "0.3", features = [
+  "Gpu",
+  "Document",
+  "Window",
+  "HtmlElement",
+  "HtmlCanvasElement",
+  "Node",
+  "Element",
+  "WebGlBuffer",
+  "WebGlVertexArrayObject",
+  "WebGl2RenderingContext",
+  "WebGlProgram",
+  "WebGlShader",
+] }
 
 [target.'cfg(not(target_os = "android"))'.dependencies]
 env_logger = "0.10"
 
 [target.'cfg(target_os = "android")'.dependencies]
-android_logger = "0.11.0"
+android_logger = "0.13"
 
 [patch.crates-io]
 
@@ -35,7 +56,6 @@ android_logger = "0.11.0"
 # out a release branch locally to be compatible)
 # android-activity = { path = "../../android-activity/android-activity" }
 
-
 [features]
 default = []
 desktop = []
@@ -48,3 +68,23 @@ crate_type=["cdylib"]
 path="src/lib.rs"
 name="test-winit-wgpu"
 required-features = [ "desktop" ]
+
+[package.metadata.android]
+package = "com.examples.na_winit_main"
+build_targets = [ "aarch64-linux-android" ] #, "armv7-linux-androideabi", "i686-linux-android", "x86_64-linux-android" ]
+
+[package.metadata.android.sdk]
+min_sdk_version = 21
+target_sdk_version = 34
+max_sdk_version = 34
+
+[package.metadata.android.signing.release]
+path = "/home/frank/.android/debug.keystore"
+keystore_password = "android"
+
+#[[package.metadata.android.uses_feature]]
+#name = "android.hardware.vulkan.level"
+#required = true
+#version = 1
+
+# For more Android options, see https://docs.rs/crate/cargo-apk/latest

--- a/na-winit-wgpu/README.md
+++ b/na-winit-wgpu/README.md
@@ -35,9 +35,6 @@ cargo apk run
 https://github.com/rust-mobile/xbuild
 
 ```
-export ANDROID_NDK_HOME="path/to/ndk"
-export ANDROID_SDK_HOME="path/to/sdk"
-
 rustup target add aarch64-linux-android
 cargo install xbuild
 

--- a/na-winit-wgpu/README.md
+++ b/na-winit-wgpu/README.md
@@ -1,6 +1,9 @@
 This is the same as agdk-winit-wgpu except it runs with `NativeActivity`
 instead of `GameActivity`
 
+Note: you may need to use compile time variable WGPU_BACKEND=GL for older devices until autodetection is fixed:
+https://github.com/gfx-rs/wgpu/issues/2384
+
 # Gradle Build
 
 ```bash
@@ -15,7 +18,7 @@ cargo ndk -t arm64-v8a -o app/src/main/jniLibs/  build
 ./gradlew installDebug
 ```
 
-# Cargo APK Build
+# Cargo APK Build (deprecated)
 
 ```bash
 export ANDROID_NDK_HOME="path/to/ndk"
@@ -26,3 +29,63 @@ cargo install cargo-apk
 
 cargo apk run
 ```
+
+# Cargo xbuild Build (supersedes cargo apk, supports iOS)
+
+https://github.com/rust-mobile/xbuild
+
+```
+export ANDROID_NDK_HOME="path/to/ndk"
+export ANDROID_SDK_HOME="path/to/sdk"
+
+rustup target add aarch64-linux-android
+cargo install xbuild
+
+x run [--release] --device adb:[adb device id]
+```
+
+Or:
+
+```
+[WGPU_BACKEND=GL] x build [--release] --format apk --platform android --arch arm64
+
+adb install -r target/x/release/android/na-winit-wgpu.apk
+adb shell am start -n com.example.na_winit_wgpu/android.app.NativeActivity
+```
+
+## Access Android devices in WSL:
+
+From powershell:
+
+```
+adb shell ip -f inet addr show wlan0
+adb tcpip 5555
+```
+
+Accept debugging access on the device, then in WSL:
+
+```
+adb connect <device ip from previous command>:5555
+adb devices
+```
+
+# Windows build (also from WSL)
+
+```
+rustup target add x86_64-pc-windows-gnu
+
+cargo build --target x86_64-pc-windows-gnu --release --features="desktop" --bin test-winit-wgpu
+
+powershell.exe Start target/x86_64-pc-windows-gnu/release/test-winit-wgpu.exe
+```
+
+# WASM build
+
+Optionally install wasm-server-runner if you want cargo run to serve the canvas.
+https://github.com/jakobhellermann/wasm-server-runner
+
+```
+RUSTFLAGS=--cfg=web_sys_unstable_apis cargo run --target wasm32-unknown-unknown [--release] --features="desktop"
+```
+
+Another suggestion if you work with javascript is to use Vite with a WASM hot reload plugin.

--- a/na-winit-wgpu/README.md
+++ b/na-winit-wgpu/README.md
@@ -4,6 +4,8 @@ instead of `GameActivity`
 Note: you may need to use compile time variable WGPU_BACKEND=GL for older devices until autodetection is fixed:
 https://github.com/gfx-rs/wgpu/issues/2384
 
+Note: the onscreen keyboard will not work on a window surface; you'd probably need to construct a SurfaceView as done in GameActivity. Better to just use GameActivity.
+
 # Gradle Build
 
 ```bash

--- a/na-winit-wgpu/src/lib.rs
+++ b/na-winit-wgpu/src/lib.rs
@@ -1,318 +1,392 @@
-use std::borrow::Cow;
+// To turn off console in Windows build:
+//#![windows_subsystem = "windows"]
+
+use std::{borrow::Cow, sync::Arc};
 
 use log::trace;
 
 use wgpu::TextureFormat;
 use wgpu::{Adapter, Device, Instance, PipelineLayout, Queue, RenderPipeline, ShaderModule};
 
-use winit::platform::run_return::EventLoopExtRunReturn;
 use winit::{
-    event::{Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop, EventLoopBuilder, EventLoopWindowTarget},
+	event::{Event, StartCause::WaitCancelled, WindowEvent},
+	event_loop::{ControlFlow, EventLoop, EventLoopBuilder, EventLoopWindowTarget},
 };
 
 #[cfg(target_os = "android")]
 use winit::platform::android::activity::AndroidApp;
 
 struct RenderState {
-    device: Device,
-    queue: Queue,
-    _shader: ShaderModule,
-    target_format: TextureFormat,
-    _pipeline_layout: PipelineLayout,
-    render_pipeline: RenderPipeline,
+	device: Device,
+	queue: Queue,
+	_shader: ShaderModule,
+	target_format: TextureFormat,
+	_pipeline_layout: PipelineLayout,
+	render_pipeline: RenderPipeline,
 }
 
-struct SurfaceState {
-    window: winit::window::Window,
-    surface: wgpu::Surface,
+struct SurfaceState<'a> {
+	window: Arc<winit::window::Window>,
+	surface: wgpu::Surface<'a>,
 }
 
-struct App {
-    instance: Instance,
-    adapter: Option<Adapter>,
-    surface_state: Option<SurfaceState>,
-    render_state: Option<RenderState>,
+struct App<'a> {
+	instance: Instance,
+	adapter: Option<Adapter>,
+	surface_state: Option<SurfaceState<'a>>,
+	render_state: Option<RenderState>,
 }
 
-impl App {
-    fn new(instance: Instance) -> Self {
-        Self {
-            instance,
-            adapter: None,
-            surface_state: None,
-            render_state: None,
-        }
-    }
+impl App<'_> {
+	fn new(instance: Instance) -> Self {
+		Self {
+			instance,
+			adapter: None,
+			surface_state: None,
+			render_state: None,
+		}
+	}
+
+	fn create_surface<T>(&mut self, elwt: &EventLoopWindowTarget<T>) {
+		#[cfg(target_arch = "wasm32")]
+		let window = {
+			use winit::{dpi::PhysicalSize, platform::web::WindowBuilderExtWebSys};
+			Arc::new(
+				winit::window::WindowBuilder::new()
+					// Automatically creates the canvas with [data-raw-handle] suitable for wgpu
+					.with_canvas(None)
+					// Winit prevents sizing with CSS, so we have to set
+					// the size manually when on web.
+					.with_inner_size(PhysicalSize::new(450, 400))
+					.with_append(true)
+					.build(elwt)
+					.unwrap(),
+			)
+		};
+		// For other platforms you could also use the WindowBuilder to set the title etc.
+		#[cfg(not(target_arch = "wasm32"))]
+		let window = Arc::new(winit::window::Window::new(elwt).unwrap());
+
+		log::info!("WGPU: creating surface for native window");
+		let surface = self
+			.instance
+			.create_surface(window.clone())
+			.expect("Failed to create surface");
+		self.surface_state = Some(SurfaceState { window, surface });
+	}
+
+	async fn init_render_state(adapter: &Adapter, target_format: TextureFormat) -> RenderState {
+		log::info!("Initializing render state");
+
+		log::info!("WGPU: requesting device");
+		// Create the logical device and command queue
+		let (device, queue) = adapter
+			.request_device(
+				&wgpu::DeviceDescriptor {
+					label: None,
+					required_features: wgpu::Features::empty(),
+					// Make sure we use the texture resolution limits from the adapter, so we can support images the size of the swapchain.
+					required_limits: wgpu::Limits::downlevel_webgl2_defaults()
+						.using_resolution(adapter.limits()),
+				},
+				None,
+			)
+			.await
+			.expect("Failed to create device");
+
+		log::info!("WGPU: loading shader");
+		// Load the shaders from disk
+		let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+			label: None,
+			source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(include_str!("shader.wgsl"))),
+		});
+
+		log::info!("WGPU: creating pipeline layout");
+		let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+			label: None,
+			bind_group_layouts: &[],
+			push_constant_ranges: &[],
+		});
+
+		log::info!("WGPU: creating render pipeline");
+		let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+			label: None,
+			layout: Some(&pipeline_layout),
+			vertex: wgpu::VertexState {
+				module: &shader,
+				entry_point: "vs_main",
+				buffers: &[],
+			},
+			fragment: Some(wgpu::FragmentState {
+				module: &shader,
+				entry_point: "fs_main",
+				targets: &[Some(target_format.into())],
+			}),
+			primitive: wgpu::PrimitiveState::default(),
+			depth_stencil: None,
+			multisample: wgpu::MultisampleState::default(),
+			multiview: None,
+		});
+
+		RenderState {
+			device,
+			queue,
+			_shader: shader,
+			target_format,
+			_pipeline_layout: pipeline_layout,
+			render_pipeline,
+		}
+	}
+
+	// We want to defer the initialization of our render state until
+	// we have a surface so we can take its format into account.
+	//
+	// After we've initialized our render state once though we
+	// expect all future surfaces will have the same format and we
+	// so this stat will remain valid.
+	async fn ensure_render_state_for_surface(&mut self) {
+		if let Some(surface_state) = &self.surface_state {
+			if self.adapter.is_none() {
+				log::info!("WGPU: requesting a suitable adapter (compatible with our surface)");
+				let adapter = self
+					.instance
+					.request_adapter(&wgpu::RequestAdapterOptions {
+						power_preference: wgpu::PowerPreference::default(),
+						force_fallback_adapter: false,
+						// Request an adapter which can render to our surface
+						compatible_surface: Some(&surface_state.surface),
+					})
+					.await
+					.expect("Failed to find an appropriate adapter");
+
+				self.adapter = Some(adapter);
+			}
+			let adapter = self.adapter.as_ref().unwrap();
+
+			if self.render_state.is_none() {
+				log::info!("WGPU: finding supported swapchain format");
+				let surface_caps = surface_state.surface.get_capabilities(adapter);
+
+				let swapchain_format = surface_caps
+					.formats
+					.iter()
+					.copied()
+					.find(|f| f.is_srgb())
+					.unwrap_or(surface_caps.formats[0]);
+
+				let rs = Self::init_render_state(adapter, swapchain_format).await;
+				self.render_state = Some(rs);
+			}
+		}
+	}
+
+	fn configure_surface_swapchain(&mut self) {
+		if let (Some(render_state), Some(surface_state)) = (&self.render_state, &self.surface_state)
+		{
+			let swapchain_format = render_state.target_format;
+			let size = surface_state.window.inner_size();
+
+			let config = wgpu::SurfaceConfiguration {
+				usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+				format: swapchain_format,
+				width: size.width,
+				height: size.height,
+				desired_maximum_frame_latency: 2,
+				//present_mode: wgpu::PresentMode::Mailbox,
+				present_mode: wgpu::PresentMode::Fifo,
+				view_formats: vec![swapchain_format],
+				//alpha_mode: wgpu::CompositeAlphaMode::Inherit,
+				alpha_mode: wgpu::CompositeAlphaMode::Opaque,
+			};
+
+			log::info!("WGPU: Configuring surface swapchain: format = {swapchain_format:?}, size = {size:?}");
+			surface_state
+				.surface
+				.configure(&render_state.device, &config);
+		}
+	}
+
+	fn queue_redraw(&self) {
+		if let Some(surface_state) = &self.surface_state {
+			trace!("Making Redraw Request");
+			surface_state.window.request_redraw();
+		}
+	}
+
+	async fn resume<T>(&mut self, event_loop: &EventLoopWindowTarget<T>) {
+		self.create_surface(event_loop);
+		self.ensure_render_state_for_surface().await;
+		self.configure_surface_swapchain();
+		self.queue_redraw();
+	}
+
+	fn render(&mut self) {
+		if let Some(ref surface_state) = self.surface_state {
+			if let Some(ref rs) = self.render_state {
+				let frame = surface_state
+					.surface
+					.get_current_texture()
+					.expect("Failed to acquire next swap chain texture");
+				let view = frame
+					.texture
+					.create_view(&wgpu::TextureViewDescriptor::default());
+				let mut encoder = rs
+					.device
+					.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+				{
+					let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+						label: None,
+						color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+							view: &view,
+							resolve_target: None,
+							ops: wgpu::Operations {
+								load: wgpu::LoadOp::Clear(wgpu::Color::GREEN),
+								store: wgpu::StoreOp::Store,
+							},
+						})],
+						depth_stencil_attachment: None,
+						occlusion_query_set: None,
+						timestamp_writes: None,
+					});
+					rpass.set_pipeline(&rs.render_pipeline);
+					rpass.draw(0..3, 0..1);
+				}
+
+				rs.queue.submit(Some(encoder.finish()));
+				frame.present();
+
+				// To animate, uncomment this to request the next frame:
+				//surface_state.window.request_redraw();
+			}
+		}
+	}
 }
 
-impl App {
-    fn create_surface<T>(&mut self, event_loop: &EventLoopWindowTarget<T>) {
-        let window = winit::window::Window::new(event_loop).unwrap();
-        log::info!("WGPU: creating surface for native window");
+fn run(event_loop: EventLoop<()>, mut app: App) {
+	log::info!("Running mainloop...");
+	event_loop.set_control_flow(ControlFlow::Wait);
 
-        // # Panics
-        // Currently create_surface is documented to only possibly fail with with WebGL2
-        let surface = unsafe {
-            self.instance
-                .create_surface(&window)
-                .expect("Failed to create surface")
-        };
-        self.surface_state = Some(SurfaceState { window, surface });
-    }
-
-    async fn init_render_state(adapter: &Adapter, target_format: TextureFormat) -> RenderState {
-        log::info!("Initializing render state");
-
-        log::info!("WGPU: requesting device");
-        // Create the logical device and command queue
-        let (device, queue) = adapter
-            .request_device(
-                &wgpu::DeviceDescriptor {
-                    label: None,
-                    features: wgpu::Features::empty(),
-                    // Make sure we use the texture resolution limits from the adapter, so we can support images the size of the swapchain.
-                    limits: wgpu::Limits::downlevel_webgl2_defaults()
-                        .using_resolution(adapter.limits()),
-                },
-                None,
-            )
-            .await
-            .expect("Failed to create device");
-
-        log::info!("WGPU: loading shader");
-        // Load the shaders from disk
-        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: None,
-            source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(include_str!("shader.wgsl"))),
-        });
-
-        log::info!("WGPU: creating pipeline layout");
-        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: None,
-            bind_group_layouts: &[],
-            push_constant_ranges: &[],
-        });
-
-        log::info!("WGPU: creating render pipeline");
-        let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-            label: None,
-            layout: Some(&pipeline_layout),
-            vertex: wgpu::VertexState {
-                module: &shader,
-                entry_point: "vs_main",
-                buffers: &[],
-            },
-            fragment: Some(wgpu::FragmentState {
-                module: &shader,
-                entry_point: "fs_main",
-                targets: &[Some(target_format.into())],
-            }),
-            primitive: wgpu::PrimitiveState::default(),
-            depth_stencil: None,
-            multisample: wgpu::MultisampleState::default(),
-            multiview: None,
-        });
-
-        RenderState {
-            device,
-            queue,
-            _shader: shader,
-            target_format,
-            _pipeline_layout: pipeline_layout,
-            render_pipeline,
-        }
-    }
-
-    // We want to defer the initialization of our render state until
-    // we have a surface so we can take its format into account.
-    //
-    // After we've initialized our render state once though we
-    // expect all future surfaces will have the same format and we
-    // so this stat will remain valid.
-    async fn ensure_render_state_for_surface(&mut self) {
-        if let Some(surface_state) = &self.surface_state {
-            if self.adapter.is_none() {
-                log::info!("WGPU: requesting a suitable adapter (compatible with our surface)");
-                let adapter = self
-                    .instance
-                    .request_adapter(&wgpu::RequestAdapterOptions {
-                        power_preference: wgpu::PowerPreference::default(),
-                        force_fallback_adapter: false,
-                        // Request an adapter which can render to our surface
-                        compatible_surface: Some(&surface_state.surface),
-                    })
-                    .await
-                    .expect("Failed to find an appropriate adapter");
-
-                self.adapter = Some(adapter);
-            }
-            let adapter = self.adapter.as_ref().unwrap();
-
-            if self.render_state.is_none() {
-                log::info!("WGPU: finding supported swapchain format");
-                let surface_caps = surface_state.surface.get_capabilities(adapter);
-                let swapchain_format = surface_caps.formats[0];
-                let rs = Self::init_render_state(adapter, swapchain_format).await;
-                self.render_state = Some(rs);
-            }
-        }
-    }
-
-    fn configure_surface_swapchain(&mut self) {
-        if let (Some(render_state), Some(surface_state)) = (&self.render_state, &self.surface_state)
-        {
-            let swapchain_format = render_state.target_format;
-            let size = surface_state.window.inner_size();
-
-            let config = wgpu::SurfaceConfiguration {
-                usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-                format: swapchain_format,
-                width: size.width,
-                height: size.height,
-                present_mode: wgpu::PresentMode::Mailbox,
-                //present_mode: wgpu::PresentMode::Fifo,
-                alpha_mode: wgpu::CompositeAlphaMode::Inherit,
-                view_formats: vec![swapchain_format],
-            };
-
-            log::info!("WGPU: Configuring surface swapchain: format = {swapchain_format:?}, size = {size:?}");
-            surface_state
-                .surface
-                .configure(&render_state.device, &config);
-        }
-    }
-
-    fn queue_redraw(&self) {
-        if let Some(surface_state) = &self.surface_state {
-            trace!("Making Redraw Request");
-            surface_state.window.request_redraw();
-        }
-    }
-
-    fn resume<T>(&mut self, event_loop: &EventLoopWindowTarget<T>) {
-        log::info!("Resumed, creating render state...");
-        self.create_surface(event_loop);
-        pollster::block_on(self.ensure_render_state_for_surface());
-        self.configure_surface_swapchain();
-        self.queue_redraw();
-    }
+	event_loop
+		.run(move |event, elwt| {
+			match event {
+				Event::Resumed => {
+					log::info!("Resumed, creating render state...");
+					#[cfg(not(target_arch = "wasm32"))]
+					pollster::block_on(app.resume(&elwt));
+				}
+				Event::Suspended => {
+					log::info!("Suspended, dropping render state...");
+					app.render_state = None;
+				}
+				Event::WindowEvent {
+					event: WindowEvent::Resized(_size),
+					..
+				} => {
+					app.configure_surface_swapchain();
+					// Winit: doesn't currently implicitly request a redraw
+					// for a resize which may be required on some platforms...
+					app.queue_redraw();
+				}
+				Event::WindowEvent {
+					event: WindowEvent::RedrawRequested,
+					..
+				} => {
+					log::info!("Handling Redraw Request");
+					app.render();
+				}
+				Event::WindowEvent {
+					event: WindowEvent::CloseRequested,
+					..
+				} => elwt.exit(),
+				Event::WindowEvent { event, .. } => match event {
+					WindowEvent::CursorMoved { .. } => {
+						// not logged, contains mouse motion
+					}
+					_ => {
+						log::info!("Window event {:#?}", event);
+					}
+				},
+				Event::AboutToWait => {
+					// not logged
+				}
+				Event::NewEvents(WaitCancelled {
+					start: _,
+					requested_resume: _,
+				}) => {
+					// not logged
+				}
+				Event::DeviceEvent {
+					device_id: _,
+					event: _,
+				} => {
+					// not logged, contains mouse motion
+				}
+				_ => {
+					log::info!("Unhandled event: {event:?}");
+				}
+			}
+		})
+		.ok();
 }
 
-fn run(mut event_loop: EventLoop<()>) {
-    log::info!("Running mainloop...");
+async fn _main(event_loop: EventLoop<()>) {
+	let wgpu_backend = option_env!("WGPU_BACKEND");
+	let backends = if wgpu_backend != None {
+		wgpu::util::parse_backends_from_comma_list(wgpu_backend.unwrap()) //wgpu::Backends::GL
+	} else {
+		wgpu::Backends::all()
+	};
+	log::info!("Using wgpu backends {}", backends.bits());
+	let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+		backends,
+		..Default::default()
+	});
 
-    // doesn't need to be re-considered later
-    let instance = Instance::new(wgpu::InstanceDescriptor {
-        backends: wgpu::Backends::all(),
-        //backends: wgpu::Backends::VULKAN,
-        //backends: wgpu::Backends::GL,
-        ..Default::default()
-    });
+	#[allow(unused_mut)]
+	let mut app = App::new(instance);
 
-    let mut app = App::new(instance);
+	#[cfg(not(target_os = "android"))]
+	app.resume(&event_loop).await;
 
-    // It's not recommended to use `run` on Android because it will call
-    // `std::process::exit` when finished which will short-circuit any
-    // Java lifecycle handling
-    event_loop.run_return(move |event, event_loop, control_flow| {
-        log::info!("Received Winit event: {event:?}");
-
-        *control_flow = ControlFlow::Wait;
-        match event {
-            Event::Resumed => {
-                app.resume(event_loop);
-            }
-            Event::Suspended => {
-                log::info!("Suspended, dropping render state...");
-                app.render_state = None;
-            }
-            Event::WindowEvent {
-                event: WindowEvent::Resized(_size),
-                ..
-            } => {
-                app.configure_surface_swapchain();
-                // Winit: doesn't currently implicitly request a redraw
-                // for a resize which may be required on some platforms...
-                app.queue_redraw();
-            }
-            Event::RedrawRequested(_) => {
-                log::info!("Handling Redraw Request");
-
-                if let Some(ref surface_state) = app.surface_state {
-                    if let Some(ref rs) = app.render_state {
-                        let frame = surface_state
-                            .surface
-                            .get_current_texture()
-                            .expect("Failed to acquire next swap chain texture");
-                        let view = frame
-                            .texture
-                            .create_view(&wgpu::TextureViewDescriptor::default());
-                        let mut encoder =
-                            rs.device
-                                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-                                    label: None,
-                                });
-                        {
-                            let mut rpass =
-                                encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                                    label: None,
-                                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                                        view: &view,
-                                        resolve_target: None,
-                                        ops: wgpu::Operations {
-                                            load: wgpu::LoadOp::Clear(wgpu::Color::GREEN),
-                                            store: true,
-                                        },
-                                    })],
-                                    depth_stencil_attachment: None,
-                                });
-                            rpass.set_pipeline(&rs.render_pipeline);
-                            rpass.draw(0..3, 0..1);
-                        }
-
-                        rs.queue.submit(Some(encoder.finish()));
-                        frame.present();
-                        surface_state.window.request_redraw();
-                    }
-                }
-            }
-            Event::WindowEvent {
-                event: WindowEvent::CloseRequested,
-                ..
-            } => *control_flow = ControlFlow::Exit,
-            Event::WindowEvent { event: _, .. } => {
-                log::info!("Window event {:#?}", event);
-            }
-            _ => {}
-        }
-    });
-}
-
-fn _main(event_loop: EventLoop<()>) {
-    run(event_loop);
+	run(event_loop, app)
 }
 
 #[allow(dead_code)]
 #[cfg(target_os = "android")]
 #[no_mangle]
 fn android_main(app: AndroidApp) {
-    use winit::platform::android::EventLoopBuilderExtAndroid;
+	use winit::platform::android::EventLoopBuilderExtAndroid;
 
-    android_logger::init_once(android_logger::Config::default().with_min_level(log::Level::Info));
+	android_logger::init_once(
+		android_logger::Config::default().with_max_level(log::LevelFilter::Info),
+	);
 
-    let event_loop = EventLoopBuilder::new().with_android_app(app).build();
-    _main(event_loop);
+	let event_loop = EventLoopBuilder::new()
+		.with_android_app(app)
+		.build()
+		.unwrap();
+	pollster::block_on(_main(event_loop));
 }
 
 #[allow(dead_code)]
-#[cfg(not(target_os = "android"))]
+#[cfg(target_arch = "wasm32")]
 fn main() {
-    env_logger::builder()
-        .filter_level(log::LevelFilter::Info) // Default Log Level
-        .parse_default_env()
-        .init();
+	console_error_panic_hook::set_once();
+	std::panic::set_hook(Box::new(console_error_panic_hook::hook));
+	console_log::init_with_level(log::Level::Info).expect("Couldn't initialize logger");
 
-    let event_loop = EventLoopBuilder::new().build();
-    _main(event_loop);
+	let event_loop = EventLoopBuilder::new().build().unwrap();
+	wasm_bindgen_futures::spawn_local(_main(event_loop));
+}
+
+#[allow(dead_code)]
+#[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
+fn main() {
+	env_logger::builder()
+		.filter_level(log::LevelFilter::Info) // Default Log Level
+		.parse_default_env()
+		.init();
+
+	let event_loop = EventLoopBuilder::new().build().unwrap();
+	pollster::block_on(_main(event_loop));
 }

--- a/na-winit-wgpu/src/lib.rs
+++ b/na-winit-wgpu/src/lib.rs
@@ -9,384 +9,384 @@ use wgpu::TextureFormat;
 use wgpu::{Adapter, Device, Instance, PipelineLayout, Queue, RenderPipeline, ShaderModule};
 
 use winit::{
-	event::{Event, StartCause::WaitCancelled, WindowEvent},
-	event_loop::{ControlFlow, EventLoop, EventLoopBuilder, EventLoopWindowTarget},
+    event::{Event, StartCause::WaitCancelled, WindowEvent},
+    event_loop::{ControlFlow, EventLoop, EventLoopBuilder, EventLoopWindowTarget},
 };
 
 #[cfg(target_os = "android")]
 use winit::platform::android::activity::AndroidApp;
 
 struct RenderState {
-	device: Device,
-	queue: Queue,
-	_shader: ShaderModule,
-	target_format: TextureFormat,
-	_pipeline_layout: PipelineLayout,
-	render_pipeline: RenderPipeline,
+    device: Device,
+    queue: Queue,
+    _shader: ShaderModule,
+    target_format: TextureFormat,
+    _pipeline_layout: PipelineLayout,
+    render_pipeline: RenderPipeline,
 }
 
 struct SurfaceState<'a> {
-	window: Arc<winit::window::Window>,
-	surface: wgpu::Surface<'a>,
+    window: Arc<winit::window::Window>,
+    surface: wgpu::Surface<'a>,
 }
 
 struct App<'a> {
-	instance: Instance,
-	adapter: Option<Adapter>,
-	surface_state: Option<SurfaceState<'a>>,
-	render_state: Option<RenderState>,
+    instance: Instance,
+    adapter: Option<Adapter>,
+    surface_state: Option<SurfaceState<'a>>,
+    render_state: Option<RenderState>,
 }
 
 impl App<'_> {
-	fn new(instance: Instance) -> Self {
-		Self {
-			instance,
-			adapter: None,
-			surface_state: None,
-			render_state: None,
-		}
-	}
+    fn new(instance: Instance) -> Self {
+        Self {
+            instance,
+            adapter: None,
+            surface_state: None,
+            render_state: None,
+        }
+    }
 
-	fn create_surface<T>(&mut self, elwt: &EventLoopWindowTarget<T>) {
-		#[cfg(target_arch = "wasm32")]
-		let window = {
-			use winit::{dpi::PhysicalSize, platform::web::WindowBuilderExtWebSys};
-			Arc::new(
-				winit::window::WindowBuilder::new()
-					// Automatically creates the canvas with [data-raw-handle] suitable for wgpu
-					.with_canvas(None)
-					// Winit prevents sizing with CSS, so we have to set
-					// the size manually when on web.
-					.with_inner_size(PhysicalSize::new(450, 400))
-					.with_append(true)
-					.build(elwt)
-					.unwrap(),
-			)
-		};
-		// For other platforms you could also use the WindowBuilder to set the title etc.
-		#[cfg(not(target_arch = "wasm32"))]
-		let window = Arc::new(winit::window::Window::new(elwt).unwrap());
+    fn create_surface<T>(&mut self, elwt: &EventLoopWindowTarget<T>) {
+        #[cfg(target_arch = "wasm32")]
+        let window = {
+            use winit::{dpi::PhysicalSize, platform::web::WindowBuilderExtWebSys};
+            Arc::new(
+                winit::window::WindowBuilder::new()
+                    // Automatically creates the canvas with [data-raw-handle] suitable for wgpu
+                    .with_canvas(None)
+                    // Winit prevents sizing with CSS, so we have to set
+                    // the size manually when on web.
+                    .with_inner_size(PhysicalSize::new(450, 400))
+                    .with_append(true)
+                    .build(elwt)
+                    .unwrap(),
+            )
+        };
+        // For other platforms you could also use the WindowBuilder to set the title etc.
+        #[cfg(not(target_arch = "wasm32"))]
+        let window = Arc::new(winit::window::Window::new(elwt).unwrap());
 
-		log::info!("WGPU: creating surface for native window");
-		let surface = self
-			.instance
-			.create_surface(window.clone())
-			.expect("Failed to create surface");
-		self.surface_state = Some(SurfaceState { window, surface });
-	}
+        log::info!("WGPU: creating surface for native window");
+        let surface = self
+            .instance
+            .create_surface(window.clone())
+            .expect("Failed to create surface");
+        self.surface_state = Some(SurfaceState { window, surface });
+    }
 
-	async fn init_render_state(adapter: &Adapter, target_format: TextureFormat) -> RenderState {
-		log::info!("Initializing render state");
+    async fn init_render_state(adapter: &Adapter, target_format: TextureFormat) -> RenderState {
+        log::info!("Initializing render state");
 
-		log::info!("WGPU: requesting device");
-		// Create the logical device and command queue
-		let (device, queue) = adapter
-			.request_device(
-				&wgpu::DeviceDescriptor {
-					label: None,
-					required_features: wgpu::Features::empty(),
-					// Make sure we use the texture resolution limits from the adapter, so we can support images the size of the swapchain.
-					required_limits: wgpu::Limits::downlevel_webgl2_defaults()
-						.using_resolution(adapter.limits()),
-				},
-				None,
-			)
-			.await
-			.expect("Failed to create device");
+        log::info!("WGPU: requesting device");
+        // Create the logical device and command queue
+        let (device, queue) = adapter
+            .request_device(
+                &wgpu::DeviceDescriptor {
+                    label: None,
+                    required_features: wgpu::Features::empty(),
+                    // Make sure we use the texture resolution limits from the adapter, so we can support images the size of the swapchain.
+                    required_limits: wgpu::Limits::downlevel_webgl2_defaults()
+                        .using_resolution(adapter.limits()),
+                },
+                None,
+            )
+            .await
+            .expect("Failed to create device");
 
-		log::info!("WGPU: loading shader");
-		// Load the shaders from disk
-		let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-			label: None,
-			source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(include_str!("shader.wgsl"))),
-		});
+        log::info!("WGPU: loading shader");
+        // Load the shaders from disk
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: None,
+            source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(include_str!("shader.wgsl"))),
+        });
 
-		log::info!("WGPU: creating pipeline layout");
-		let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-			label: None,
-			bind_group_layouts: &[],
-			push_constant_ranges: &[],
-		});
+        log::info!("WGPU: creating pipeline layout");
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: None,
+            bind_group_layouts: &[],
+            push_constant_ranges: &[],
+        });
 
-		log::info!("WGPU: creating render pipeline");
-		let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-			label: None,
-			layout: Some(&pipeline_layout),
-			vertex: wgpu::VertexState {
-				module: &shader,
-				entry_point: "vs_main",
-				buffers: &[],
-			},
-			fragment: Some(wgpu::FragmentState {
-				module: &shader,
-				entry_point: "fs_main",
-				targets: &[Some(target_format.into())],
-			}),
-			primitive: wgpu::PrimitiveState::default(),
-			depth_stencil: None,
-			multisample: wgpu::MultisampleState::default(),
-			multiview: None,
-		});
+        log::info!("WGPU: creating render pipeline");
+        let render_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: None,
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: "vs_main",
+                buffers: &[],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: "fs_main",
+                targets: &[Some(target_format.into())],
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+        });
 
-		RenderState {
-			device,
-			queue,
-			_shader: shader,
-			target_format,
-			_pipeline_layout: pipeline_layout,
-			render_pipeline,
-		}
-	}
+        RenderState {
+            device,
+            queue,
+            _shader: shader,
+            target_format,
+            _pipeline_layout: pipeline_layout,
+            render_pipeline,
+        }
+    }
 
-	// We want to defer the initialization of our render state until
-	// we have a surface so we can take its format into account.
-	//
-	// After we've initialized our render state once though we
-	// expect all future surfaces will have the same format and we
-	// so this stat will remain valid.
-	async fn ensure_render_state_for_surface(&mut self) {
-		if let Some(surface_state) = &self.surface_state {
-			if self.adapter.is_none() {
-				log::info!("WGPU: requesting a suitable adapter (compatible with our surface)");
-				let adapter = self
-					.instance
-					.request_adapter(&wgpu::RequestAdapterOptions {
-						power_preference: wgpu::PowerPreference::default(),
-						force_fallback_adapter: false,
-						// Request an adapter which can render to our surface
-						compatible_surface: Some(&surface_state.surface),
-					})
-					.await
-					.expect("Failed to find an appropriate adapter");
+    // We want to defer the initialization of our render state until
+    // we have a surface so we can take its format into account.
+    //
+    // After we've initialized our render state once though we
+    // expect all future surfaces will have the same format and we
+    // so this stat will remain valid.
+    async fn ensure_render_state_for_surface(&mut self) {
+        if let Some(surface_state) = &self.surface_state {
+            if self.adapter.is_none() {
+                log::info!("WGPU: requesting a suitable adapter (compatible with our surface)");
+                let adapter = self
+                    .instance
+                    .request_adapter(&wgpu::RequestAdapterOptions {
+                        power_preference: wgpu::PowerPreference::default(),
+                        force_fallback_adapter: false,
+                        // Request an adapter which can render to our surface
+                        compatible_surface: Some(&surface_state.surface),
+                    })
+                    .await
+                    .expect("Failed to find an appropriate adapter");
 
-				self.adapter = Some(adapter);
-			}
-			let adapter = self.adapter.as_ref().unwrap();
+                self.adapter = Some(adapter);
+            }
+            let adapter = self.adapter.as_ref().unwrap();
 
-			if self.render_state.is_none() {
-				log::info!("WGPU: finding supported swapchain format");
-				let surface_caps = surface_state.surface.get_capabilities(adapter);
+            if self.render_state.is_none() {
+                log::info!("WGPU: finding supported swapchain format");
+                let surface_caps = surface_state.surface.get_capabilities(adapter);
 
-				let swapchain_format = surface_caps
-					.formats
-					.iter()
-					.copied()
-					.find(|f| f.is_srgb())
-					.unwrap_or(surface_caps.formats[0]);
+                let swapchain_format = surface_caps
+                    .formats
+                    .iter()
+                    .copied()
+                    .find(|f| f.is_srgb())
+                    .unwrap_or(surface_caps.formats[0]);
 
-				let rs = Self::init_render_state(adapter, swapchain_format).await;
-				self.render_state = Some(rs);
-			}
-		}
-	}
+                let rs = Self::init_render_state(adapter, swapchain_format).await;
+                self.render_state = Some(rs);
+            }
+        }
+    }
 
-	fn configure_surface_swapchain(&mut self) {
-		if let (Some(render_state), Some(surface_state)) = (&self.render_state, &self.surface_state)
-		{
-			let swapchain_format = render_state.target_format;
-			let size = surface_state.window.inner_size();
+    fn configure_surface_swapchain(&mut self) {
+        if let (Some(render_state), Some(surface_state)) = (&self.render_state, &self.surface_state)
+        {
+            let swapchain_format = render_state.target_format;
+            let size = surface_state.window.inner_size();
 
-			let config = wgpu::SurfaceConfiguration {
-				usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-				format: swapchain_format,
-				width: size.width,
-				height: size.height,
-				desired_maximum_frame_latency: 2,
-				//present_mode: wgpu::PresentMode::Mailbox,
-				present_mode: wgpu::PresentMode::Fifo,
-				view_formats: vec![swapchain_format],
-				//alpha_mode: wgpu::CompositeAlphaMode::Inherit,
-				alpha_mode: wgpu::CompositeAlphaMode::Opaque,
-			};
+            let config = wgpu::SurfaceConfiguration {
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                format: swapchain_format,
+                width: size.width,
+                height: size.height,
+                desired_maximum_frame_latency: 2,
+                //present_mode: wgpu::PresentMode::Mailbox,
+                present_mode: wgpu::PresentMode::Fifo,
+                view_formats: vec![swapchain_format],
+                //alpha_mode: wgpu::CompositeAlphaMode::Inherit,
+                alpha_mode: wgpu::CompositeAlphaMode::Opaque,
+            };
 
-			log::info!("WGPU: Configuring surface swapchain: format = {swapchain_format:?}, size = {size:?}");
-			surface_state
-				.surface
-				.configure(&render_state.device, &config);
-		}
-	}
+            log::info!("WGPU: Configuring surface swapchain: format = {swapchain_format:?}, size = {size:?}");
+            surface_state
+                .surface
+                .configure(&render_state.device, &config);
+        }
+    }
 
-	fn queue_redraw(&self) {
-		if let Some(surface_state) = &self.surface_state {
-			trace!("Making Redraw Request");
-			surface_state.window.request_redraw();
-		}
-	}
+    fn queue_redraw(&self) {
+        if let Some(surface_state) = &self.surface_state {
+            trace!("Making Redraw Request");
+            surface_state.window.request_redraw();
+        }
+    }
 
-	async fn resume<T>(&mut self, event_loop: &EventLoopWindowTarget<T>) {
-		self.create_surface(event_loop);
-		self.ensure_render_state_for_surface().await;
-		self.configure_surface_swapchain();
-		self.queue_redraw();
-	}
+    async fn resume<T>(&mut self, event_loop: &EventLoopWindowTarget<T>) {
+        self.create_surface(event_loop);
+        self.ensure_render_state_for_surface().await;
+        self.configure_surface_swapchain();
+        self.queue_redraw();
+    }
 
-	fn render(&mut self) {
-		if let Some(ref surface_state) = self.surface_state {
-			if let Some(ref rs) = self.render_state {
-				let frame = surface_state
-					.surface
-					.get_current_texture()
-					.expect("Failed to acquire next swap chain texture");
-				let view = frame
-					.texture
-					.create_view(&wgpu::TextureViewDescriptor::default());
-				let mut encoder = rs
-					.device
-					.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
-				{
-					let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-						label: None,
-						color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-							view: &view,
-							resolve_target: None,
-							ops: wgpu::Operations {
-								load: wgpu::LoadOp::Clear(wgpu::Color::GREEN),
-								store: wgpu::StoreOp::Store,
-							},
-						})],
-						depth_stencil_attachment: None,
-						occlusion_query_set: None,
-						timestamp_writes: None,
-					});
-					rpass.set_pipeline(&rs.render_pipeline);
-					rpass.draw(0..3, 0..1);
-				}
+    fn render(&mut self) {
+        if let Some(ref surface_state) = self.surface_state {
+            if let Some(ref rs) = self.render_state {
+                let frame = surface_state
+                    .surface
+                    .get_current_texture()
+                    .expect("Failed to acquire next swap chain texture");
+                let view = frame
+                    .texture
+                    .create_view(&wgpu::TextureViewDescriptor::default());
+                let mut encoder = rs
+                    .device
+                    .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+                {
+                    let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                        label: None,
+                        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                            view: &view,
+                            resolve_target: None,
+                            ops: wgpu::Operations {
+                                load: wgpu::LoadOp::Clear(wgpu::Color::GREEN),
+                                store: wgpu::StoreOp::Store,
+                            },
+                        })],
+                        depth_stencil_attachment: None,
+                        occlusion_query_set: None,
+                        timestamp_writes: None,
+                    });
+                    rpass.set_pipeline(&rs.render_pipeline);
+                    rpass.draw(0..3, 0..1);
+                }
 
-				rs.queue.submit(Some(encoder.finish()));
-				frame.present();
+                rs.queue.submit(Some(encoder.finish()));
+                frame.present();
 
-				// To animate, uncomment this to request the next frame:
-				//surface_state.window.request_redraw();
-			}
-		}
-	}
+                // To animate, uncomment this to request the next frame:
+                //surface_state.window.request_redraw();
+            }
+        }
+    }
 }
 
 fn run(event_loop: EventLoop<()>, mut app: App) {
-	log::info!("Running mainloop...");
-	event_loop.set_control_flow(ControlFlow::Wait);
+    log::info!("Running mainloop...");
+    event_loop.set_control_flow(ControlFlow::Wait);
 
-	event_loop
-		.run(move |event, elwt| {
-			match event {
-				Event::Resumed => {
-					log::info!("Resumed, creating render state...");
-					#[cfg(not(target_arch = "wasm32"))]
-					pollster::block_on(app.resume(&elwt));
-				}
-				Event::Suspended => {
-					log::info!("Suspended, dropping render state...");
-					app.render_state = None;
-				}
-				Event::WindowEvent {
-					event: WindowEvent::Resized(_size),
-					..
-				} => {
-					app.configure_surface_swapchain();
-					// Winit: doesn't currently implicitly request a redraw
-					// for a resize which may be required on some platforms...
-					app.queue_redraw();
-				}
-				Event::WindowEvent {
-					event: WindowEvent::RedrawRequested,
-					..
-				} => {
-					log::info!("Handling Redraw Request");
-					app.render();
-				}
-				Event::WindowEvent {
-					event: WindowEvent::CloseRequested,
-					..
-				} => elwt.exit(),
-				Event::WindowEvent { event, .. } => match event {
-					WindowEvent::CursorMoved { .. } => {
-						// not logged, contains mouse motion
-					}
-					_ => {
-						log::info!("Window event {:#?}", event);
-					}
-				},
-				Event::AboutToWait => {
-					// not logged
-				}
-				Event::NewEvents(WaitCancelled {
-					start: _,
-					requested_resume: _,
-				}) => {
-					// not logged
-				}
-				Event::DeviceEvent {
-					device_id: _,
-					event: _,
-				} => {
-					// not logged, contains mouse motion
-				}
-				_ => {
-					log::info!("Unhandled event: {event:?}");
-				}
-			}
-		})
-		.ok();
+    event_loop
+        .run(move |event, elwt| {
+            match event {
+                Event::Resumed => {
+                    log::info!("Resumed, creating render state...");
+                    #[cfg(not(target_arch = "wasm32"))]
+                    pollster::block_on(app.resume(&elwt));
+                }
+                Event::Suspended => {
+                    log::info!("Suspended, dropping render state...");
+                    app.render_state = None;
+                }
+                Event::WindowEvent {
+                    event: WindowEvent::Resized(_size),
+                    ..
+                } => {
+                    app.configure_surface_swapchain();
+                    // Winit: doesn't currently implicitly request a redraw
+                    // for a resize which may be required on some platforms...
+                    app.queue_redraw();
+                }
+                Event::WindowEvent {
+                    event: WindowEvent::RedrawRequested,
+                    ..
+                } => {
+                    log::info!("Handling Redraw Request");
+                    app.render();
+                }
+                Event::WindowEvent {
+                    event: WindowEvent::CloseRequested,
+                    ..
+                } => elwt.exit(),
+                Event::WindowEvent { event, .. } => match event {
+                    WindowEvent::CursorMoved { .. } => {
+                        // not logged, contains mouse motion
+                    }
+                    _ => {
+                        log::info!("Window event {:#?}", event);
+                    }
+                },
+                Event::AboutToWait => {
+                    // not logged
+                }
+                Event::NewEvents(WaitCancelled {
+                    start: _,
+                    requested_resume: _,
+                }) => {
+                    // not logged
+                }
+                Event::DeviceEvent {
+                    device_id: _,
+                    event: _,
+                } => {
+                    // not logged, contains mouse motion
+                }
+                _ => {
+                    log::info!("Unhandled event: {event:?}");
+                }
+            }
+        })
+        .ok();
 }
 
 async fn _main(event_loop: EventLoop<()>) {
-	let wgpu_backend = option_env!("WGPU_BACKEND");
-	let backends = if wgpu_backend != None {
-		wgpu::util::parse_backends_from_comma_list(wgpu_backend.unwrap()) //wgpu::Backends::GL
-	} else {
-		wgpu::Backends::all()
-	};
-	log::info!("Using wgpu backends {}", backends.bits());
-	let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
-		backends,
-		..Default::default()
-	});
+    let wgpu_backend = option_env!("WGPU_BACKEND");
+    let backends = if wgpu_backend != None {
+        wgpu::util::parse_backends_from_comma_list(wgpu_backend.unwrap()) //wgpu::Backends::GL
+    } else {
+        wgpu::Backends::all()
+    };
+    log::info!("Using wgpu backends {}", backends.bits());
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+        backends,
+        ..Default::default()
+    });
 
-	#[allow(unused_mut)]
-	let mut app = App::new(instance);
+    #[allow(unused_mut)]
+    let mut app = App::new(instance);
 
-	#[cfg(not(target_os = "android"))]
-	app.resume(&event_loop).await;
+    #[cfg(not(target_os = "android"))]
+    app.resume(&event_loop).await;
 
-	run(event_loop, app)
+    run(event_loop, app)
 }
 
 #[allow(dead_code)]
 #[cfg(target_os = "android")]
 #[no_mangle]
 fn android_main(app: AndroidApp) {
-	use winit::platform::android::EventLoopBuilderExtAndroid;
+    use winit::platform::android::EventLoopBuilderExtAndroid;
 
-	android_logger::init_once(
-		android_logger::Config::default().with_max_level(log::LevelFilter::Info),
-	);
+    android_logger::init_once(
+        android_logger::Config::default().with_max_level(log::LevelFilter::Info),
+    );
 
-	let event_loop = EventLoopBuilder::new()
-		.with_android_app(app)
-		.build()
-		.unwrap();
-	pollster::block_on(_main(event_loop));
+    let event_loop = EventLoopBuilder::new()
+        .with_android_app(app)
+        .build()
+        .unwrap();
+    pollster::block_on(_main(event_loop));
 }
 
 #[allow(dead_code)]
 #[cfg(target_arch = "wasm32")]
 fn main() {
-	console_error_panic_hook::set_once();
-	std::panic::set_hook(Box::new(console_error_panic_hook::hook));
-	console_log::init_with_level(log::Level::Info).expect("Couldn't initialize logger");
+    console_error_panic_hook::set_once();
+    std::panic::set_hook(Box::new(console_error_panic_hook::hook));
+    console_log::init_with_level(log::Level::Info).expect("Couldn't initialize logger");
 
-	let event_loop = EventLoopBuilder::new().build().unwrap();
-	wasm_bindgen_futures::spawn_local(_main(event_loop));
+    let event_loop = EventLoopBuilder::new().build().unwrap();
+    wasm_bindgen_futures::spawn_local(_main(event_loop));
 }
 
 #[allow(dead_code)]
 #[cfg(not(any(target_os = "android", target_arch = "wasm32")))]
 fn main() {
-	env_logger::builder()
-		.filter_level(log::LevelFilter::Info) // Default Log Level
-		.parse_default_env()
-		.init();
+    env_logger::builder()
+        .filter_level(log::LevelFilter::Info) // Default Log Level
+        .parse_default_env()
+        .init();
 
-	let event_loop = EventLoopBuilder::new().build().unwrap();
-	pollster::block_on(_main(event_loop));
+    let event_loop = EventLoopBuilder::new().build().unwrap();
+    pollster::block_on(_main(event_loop));
 }

--- a/na-winit-wgpu/src/lib.rs
+++ b/na-winit-wgpu/src/lib.rs
@@ -345,7 +345,8 @@ async fn _main(event_loop: EventLoop<()>) {
     #[allow(unused_mut)]
     let mut app = App::new(instance);
 
-    #[cfg(not(target_os = "android"))]
+    // spawn_local causes ownership troubles in the event loop closure, so just init here
+    #[cfg(target_arch = "wasm32")]
     app.resume(&event_loop).await;
 
     run(event_loop, app)


### PR DESCRIPTION
It has been very difficult to get wgpu to work (especially on older devices), so I'm sharing my result.
Now that Android and WASM support has improved in all crates, I managed to support all platforms with the latest crate versions.

I know the intention of this repository is Android, but I believe having a ready-to-go example with cross-platform instructions is critical to support both developers and libraries on this new platform.

Unfortunately I don't have time to update all examples, but I think it's best to at least update this one for now.

I'm not sure about the web-sys features but it seems to support webgl and webgpu like this.

I set present_mode to fifo and alpha_mode to opaque, because that's what worked on my Android 8.1 device and is probably more widely supported. I left the other options commented out.

I also moved the rendering to App. Perhaps App should also get an input(event) and tick/update() function.

I also introduced WGPU_BACKEND as a compile time variable.

I also commented out the unnecessary request_redraw, with a comment that one could use it for animation.